### PR TITLE
Add layout() in ButtonGroup field

### DIFF
--- a/src/Fields/ButtonGroup.php
+++ b/src/Fields/ButtonGroup.php
@@ -32,4 +32,15 @@ class ButtonGroup extends Field
     use Wrapper;
 
     protected $type = 'button_group';
+
+    public function layout(string $layout): self
+    {
+        if (!in_array($layout, ['vertical', 'horizontal'])) {
+            throw new InvalidArgumentException("Invalid argument layout [$layout].");
+        }
+
+        $this->config->set('layout', $layout);
+
+        return $this;
+    }
 }


### PR DESCRIPTION
Add layout() in ButtonGroup field.

Accepts `vertical` or `horizontal`.

Fixes #61 