### PR TITLE
Fix ConditionalLogic docs to use select field keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,11 +598,11 @@ Select::make('Type')
     ]),
 File::make('Document', 'file')
     ->conditionalLogic([
-        ConditionalLogic::if('type')->equals('Document')
+        ConditionalLogic::if('type')->equals('document')
     ]),
 Url::make('Link', 'url')
     ->conditionalLogic([
-        ConditionalLogic::if('type')->equals('Link to resource')
+        ConditionalLogic::if('type')->equals('link')
     ]),
 ```
 


### PR DESCRIPTION
Hi there!

When using a Select field using `key => value` choice definitions, the parameter passed to the ConditionalLogic comparison function should be the choice's `key`, not its `value`.

## Proposed Changes

  - Fix README ConditionalLogic section to use Select field keys instead of values
