### PR TITLE
Adds customConfig method in Field

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -44,6 +44,13 @@ abstract class Field
         return new static($label, $name);
     }
 
+    public function customConfig(string $key, $value): self
+    {
+        $this->config->set($key, $value);
+
+        return $this;
+    }
+
     public function setParentKey(string $parentKey): void
     {
         $this->parentKey = $parentKey;


### PR DESCRIPTION
Hi there!

So, today I came across [a plugin](https://github.com/mcguffin/acf-quickedit-fields) which allows quick and bulk editing ACF fields. It uses custom config keys inside each field to enable/disable the quick/bulk editing behaviour.

When looking through Extended ACF, I couldn't find a way of setting these one-off config keys. Since I will use them in a single field, I wouldn't like to extend a class just for this one case.

So I'm proposing adding a `customConfig` method to the core `Field` class, which allows manually setting a config key/value pair.

Sample usage:

```
Select::make('Test field')
    ->customConfig('allow_bulkedit', 1)
    ->customConfig('allow_quickedit', 1),
```

Cheers!