### PR TITLE
fix(docs): Fix undefined method File::defaultValue() in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,6 @@ use WordPlate\Acf\Fields\File;
 
 File::make('Resturant Menu', 'menu')
     ->instructions('Add the menu <strong>pdf</strong> file.')
-    ->defaultValue(false)
     ->mimeTypes(['pdf'])
     ->library('all') // all or uploadedTo
     ->fileSize('400 KB', 5) // MB if entered as int


### PR DESCRIPTION
There is a call to an undefined method `defaultValue()` in the `File` example of the `README.md`.
I just removed that line.