### PR TITLE
Fixes wordplate/extended-acf#82

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@
 ## 7.0.0
 
 - Added new field classes API
-- Removed acf\_\* helper functions
+- Removed acf_* helper functions
 - Removed is_layout helper functions
 
 ## 6.0.0
@@ -163,7 +163,7 @@
 
 ## 0.2.1
 
-- Added duplicate key exception
+- Added duplicate key exception 
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 ## Unreleased
 
-- Renamed Taxonomy field's `createTerm` to `addTerm` and added boolean argument
-- Added boolean argument to Taxonomy field's `loadTerms`
-- Added boolean argument to Taxonomy field's `saveTerms`
+- Renamed taxonomy field's `createTerm` to `addTerm`
+- Added boolean argument to taxonomy field's `loadTerms`, `saveTerms` and `addTerm`
 
 ## 8.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Unreleased
+
+- Renamed Taxonomy field's `createTerm` to `addTerm` and added boolean argument
+- Added boolean argument to Taxonomy field's `loadTerms`
+- Added boolean argument to Taxonomy field's `saveTerms`
+
 ## 8.6.0
 
 - Updated minimum PHP version to 7.3
@@ -73,7 +79,7 @@
 ## 7.0.0
 
 - Added new field classes API
-- Removed acf_* helper functions
+- Removed acf\_\* helper functions
 - Removed is_layout helper functions
 
 ## 6.0.0
@@ -157,7 +163,7 @@
 
 ## 0.2.1
 
-- Added duplicate key exception 
+- Added duplicate key exception
 
 ## 0.2.0
 

--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ Taxonomy::make('Cinemas')
     ->instructions('Select one or more cinema terms.')
     ->taxonomy('cinema')
     ->appearance('checkbox') // checkbox, multi_select, radio or select
-    ->createTerms() // Allow new terms to be created whilst editing
+    ->createTerms(true) // Allow new terms to be created whilst editing. true (default) or false
     ->loadTerms() // Load value from posts terms
     ->saveTerms() // Connect selected terms to the post
     ->returnFormat('id'); // id or object

--- a/README.md
+++ b/README.md
@@ -551,9 +551,9 @@ Taxonomy::make('Cinemas')
     ->instructions('Select one or more cinema terms.')
     ->taxonomy('cinema')
     ->appearance('checkbox') // checkbox, multi_select, radio or select
-    ->createTerms(true) // Allow new terms to be created whilst editing. true (default) or false
-    ->loadTerms() // Load value from posts terms
-    ->saveTerms() // Connect selected terms to the post
+    ->addTerm(true) // Allow new terms to be created whilst editing (true or false)
+    ->loadTerms(true) // Load value from posts terms (true or false)
+    ->saveTerms(true) // Connect selected terms to the post (true or false)
     ->returnFormat('id'); // id or object
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "8.6-dev"
+            "dev-master": "9.0-dev"
         }
     },
     "autoload": {

--- a/src/Fields/Taxonomy.php
+++ b/src/Fields/Taxonomy.php
@@ -44,9 +44,9 @@ class Taxonomy extends Field
         return $this;
     }
 
-    public function createTerms(): self
+    public function createTerms(bool $isAllowed = true): self
     {
-        $this->config->set('add_term', true);
+        $this->config->set('add_term', $isAllowed);
 
         return $this;
     }

--- a/src/Fields/Taxonomy.php
+++ b/src/Fields/Taxonomy.php
@@ -44,23 +44,23 @@ class Taxonomy extends Field
         return $this;
     }
 
-    public function createTerms(bool $isAllowed = true): self
+    public function addTerm(bool $addTerm = true): self
     {
-        $this->config->set('add_term', $isAllowed);
+        $this->config->set('add_term', $addTerm);
 
         return $this;
     }
 
-    public function loadTerms(): self
+    public function loadTerms(bool $loadTerms = true): self
     {
-        $this->config->set('load_terms', true);
+        $this->config->set('load_terms', $loadTerms);
 
         return $this;
     }
 
-    public function saveTerms(): self
+    public function saveTerms(bool $saveTerms = true): self
     {
-        $this->config->set('save_terms', true);
+        $this->config->set('save_terms', $saveTerms);
 
         return $this;
     }

--- a/tests/Fields/TaxonomyTest.php
+++ b/tests/Fields/TaxonomyTest.php
@@ -38,37 +38,19 @@ class TaxonomyTest extends TestCase
 
     public function testCanAddTerm()
     {
-        $field = Taxonomy::make('Taxonomy Can Add Term')->addTerm(true)->toArray();
-        $this->assertTrue($field['add_term']);
-    }
-
-    public function testCannotAddTerm()
-    {
-        $field = Taxonomy::make('Taxonomy Cannot Add Term')->addTerm(false)->toArray();
+        $field = Taxonomy::make('Taxonomy Add Term')->addTerm(false)->toArray();
         $this->assertFalse($field['add_term']);
     }
 
-    public function testShouldLoadTerms()
+    public function testLoadTerms()
     {
-        $field = Taxonomy::make('Taxonomy Should Load Terms')->loadTerms(true)->toArray();
-        $this->assertTrue($field['load_terms']);
-    }
-
-    public function testShouldNotLoadTerms()
-    {
-        $field = Taxonomy::make('Taxonomy Should Not Load Terms')->loadTerms(false)->toArray();
+        $field = Taxonomy::make('Taxonomy Load Terms')->loadTerms(false)->toArray();
         $this->assertFalse($field['load_terms']);
     }
 
     public function testShouldSaveTerms()
     {
-        $field = Taxonomy::make('Taxonomy Should Save Terms')->saveTerms(true)->toArray();
-        $this->assertTrue($field['save_terms']);
-    }
-
-    public function testShouldNotSaveTerms()
-    {
-        $field = Taxonomy::make('Taxonomy Should Not Save Terms')->saveTerms(false)->toArray();
+        $field = Taxonomy::make('Taxonomy Save Terms')->saveTerms(false)->toArray();
         $this->assertFalse($field['save_terms']);
     }
 

--- a/tests/Fields/TaxonomyTest.php
+++ b/tests/Fields/TaxonomyTest.php
@@ -42,6 +42,12 @@ class TaxonomyTest extends TestCase
         $this->assertTrue($field['add_term']);
     }
 
+    public function testDisableCreateTerms()
+    {
+        $field = Taxonomy::make('Taxonomy Undefined Create Terms')->createTerms(false)->toArray();
+        $this->assertFalse($field['add_term']);
+    }
+
     public function testLoadTerms()
     {
         $field = Taxonomy::make('Taxonomy Load Terms')->loadTerms()->toArray();

--- a/tests/Fields/TaxonomyTest.php
+++ b/tests/Fields/TaxonomyTest.php
@@ -36,28 +36,40 @@ class TaxonomyTest extends TestCase
         Taxonomy::make('Invalid Taxonomy Appearance')->appearance('test')->toArray();
     }
 
-    public function testCreateTerms()
+    public function testCanAddTerm()
     {
-        $field = Taxonomy::make('Taxonomy Create Terms')->createTerms()->toArray();
+        $field = Taxonomy::make('Taxonomy Can Add Term')->addTerm(true)->toArray();
         $this->assertTrue($field['add_term']);
     }
 
-    public function testDisableCreateTerms()
+    public function testCannotAddTerm()
     {
-        $field = Taxonomy::make('Taxonomy Undefined Create Terms')->createTerms(false)->toArray();
+        $field = Taxonomy::make('Taxonomy Cannot Add Term')->addTerm(false)->toArray();
         $this->assertFalse($field['add_term']);
     }
 
-    public function testLoadTerms()
+    public function testShouldLoadTerms()
     {
-        $field = Taxonomy::make('Taxonomy Load Terms')->loadTerms()->toArray();
+        $field = Taxonomy::make('Taxonomy Should Load Terms')->loadTerms(true)->toArray();
         $this->assertTrue($field['load_terms']);
     }
 
-    public function testSaveTerms()
+    public function testShouldNotLoadTerms()
     {
-        $field = Taxonomy::make('Taxonomy Save Terms')->saveTerms()->toArray();
+        $field = Taxonomy::make('Taxonomy Should Not Load Terms')->loadTerms(false)->toArray();
+        $this->assertFalse($field['load_terms']);
+    }
+
+    public function testShouldSaveTerms()
+    {
+        $field = Taxonomy::make('Taxonomy Should Save Terms')->saveTerms(true)->toArray();
         $this->assertTrue($field['save_terms']);
+    }
+
+    public function testShouldNotSaveTerms()
+    {
+        $field = Taxonomy::make('Taxonomy Should Not Save Terms')->saveTerms(false)->toArray();
+        $this->assertFalse($field['save_terms']);
     }
 
     public function testTaxonomy()


### PR DESCRIPTION
This PR fixes #82 by adding allowing a user to pass a boolean to `Taxonomy::createTerms`.
No argument defaults to `true` for backwards compatibility.