### PR TITLE
docs: Specify name format of toolbar in Wysiwyg

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Wysiwyg::make('Content')
     ->instructions('Add the text content.')
     ->mediaUpload(false)
     ->tabs('visual')
-    ->toolbar('simple')
+    ->toolbar('simple') // toolbar name in snake_case
     ->required();
 ```
 


### PR DESCRIPTION
Update Wysiwyg docs to specify the expected format of toolbar name. See issue #84 .
