### PR TITLE
Fixed issue 69: Children in repeaters 

### DIFF
--- a/src/ConditionalLogic.php
+++ b/src/ConditionalLogic.php
@@ -110,7 +110,8 @@ class ConditionalLogic
 
     public function setParentKey(string $parentKey): void
     {
-        $this->parentKey = $parentKey;
+        $resolvedParentKey = Key::resolve($parentKey, $this->name);
+        $this->parentKey = $resolvedParentKey;
     }
 
     public function toArray(): array

--- a/src/Key.php
+++ b/src/Key.php
@@ -60,4 +60,25 @@ class Key
 
         return $key;
     }
+    public static function resolve($parentKey = '', $key) { // _mwmw_test_parent_key, some_text
+        $hashedKey = self::hash($parentKey . '_' . $key); //  349f9s
+        $parentKeyPieces = explode('_', $parentKey); // [ '', 'mwmw', 'test', 'parent', 'key' ]
+
+        // If field_349f9s (_mwmw_test_parent_key_some_text) does not exist in self::$keys
+        if( ! in_array( 'field_' . $hashedKey, self::$keys )) {
+
+            // Remove last '_item' of parent key and check again.
+            while( count($parentKeyPieces) > 1 ) {
+                $parentKeyPiece = array_pop($parentKeyPieces); // [ '', 'mwmw', 'test', 'parent' ]
+                $potentialParentKey = join('_', $parentKeyPieces); // _mwm_test_parent
+                
+                $hashedKey = self::hash($potentialParentKey . '_' . $key); // 235efe
+                if(in_array( 'field_' . $hashedKey, self::$keys )) { // Check if field_235efe is in self::$keys
+                    $parentKey = $potentialParentKey;
+                    break;
+                }
+            }
+        }
+        return $parentKey;
+    }
 }


### PR DESCRIPTION
Tried to leave a comment trail so the code is easier to follow. The tl;dr of it is the repeater's key was being added to the conditionals key. There's a new function called `Key::resolve()` which will spilt, pop, and join the keys until it finds the correct combination.