### PR TITLE
Working on version 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Next
 
 - Added `readonly` and `disabled` to date fields
+- Rename `Radio` class to `RadioButton`
+- Rename `Wysiwyg` class to `WysiwygEditor`
 
 ## 10.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Added `readonly` and `disabled` to date fields
 - Rename `Radio` class to `RadioButton`
 - Rename `Wysiwyg` class to `WysiwygEditor`
-- Updated field label to name conversion from kebab-case to snake_case
+- Updated field label to name conversion from `kebab-case` to `snake_case`
 
 ## 10.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added `readonly` and `disabled` to date fields
 - Rename `Radio` class to `RadioButton`
 - Rename `Wysiwyg` class to `WysiwygEditor`
+- Updated field label to name conversion from kebab-case to snake_case
 
 ## 10.0.0
 

--- a/README.md
+++ b/README.md
@@ -213,9 +213,9 @@ Checkbox::make('Color')
 **Radio** - The [radio button field](https://www.advancedcustomfields.com/resources/radio-button) creates a list of select-able inputs.
 
 ```php
-use WordPlate\Acf\Fields\Radio;
+use WordPlate\Acf\Fields\RadioButton;
 
-Radio::make('Color')
+RadioButton::make('Color')
     ->instructions('Select the text color.')
     ->choices([
         'cyan' => 'Cyan',
@@ -320,9 +320,9 @@ Oembed::make('Tweet')
 **WYSIWYG** - The [WYSIWYG field](https://www.advancedcustomfields.com/resources/wysiwyg-editor) creates a full WordPress tinyMCE content editor.
 
 ```php
-use WordPlate\Acf\Fields\Wysiwyg;
+use WordPlate\Acf\Fields\WysiwygEditor;
 
-Wysiwyg::make('Content')
+WysiwygEditor::make('Content')
     ->instructions('Add the text content.')
     ->mediaUpload(false)
     ->tabs('visual')

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -32,13 +32,9 @@ abstract class Field
 
     public function __construct(string $label, ?string $name = null)
     {
-        if ($name === null) {
-            $name = Key::sanitize($label);
-        }
-
         $this->config = new Config([
             'label' => $label,
-            'name' => $name,
+            'name' => $name ?? Key::sanitize($label),
         ]);
     }
 

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -32,9 +32,13 @@ abstract class Field
 
     public function __construct(string $label, ?string $name = null)
     {
+        if ($name === null) {
+            $name = str_replace('-', '_', sanitize_title($label));
+        }
+
         $this->config = new Config([
             'label' => $label,
-            'name' => $name ?? sanitize_title($label),
+            'name' => $name,
         ]);
     }
 

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -33,7 +33,7 @@ abstract class Field
     public function __construct(string $label, ?string $name = null)
     {
         if ($name === null) {
-            $name = str_replace('-', '_', sanitize_title($label));
+            $name = Key::sanitize($label);
         }
 
         $this->config = new Config([

--- a/src/Fields/RadioButton.php
+++ b/src/Fields/RadioButton.php
@@ -24,7 +24,7 @@ use WordPlate\Acf\Fields\Attributes\Required;
 use WordPlate\Acf\Fields\Attributes\ReturnFormat;
 use WordPlate\Acf\Fields\Attributes\Wrapper;
 
-class Radio extends Field
+class RadioButton extends Field
 {
     use Choices;
     use DefaultValue;

--- a/src/Fields/WysiwygEditor.php
+++ b/src/Fields/WysiwygEditor.php
@@ -20,7 +20,7 @@ use WordPlate\Acf\Fields\Attributes\Instructions;
 use WordPlate\Acf\Fields\Attributes\Required;
 use WordPlate\Acf\Fields\Attributes\Wrapper;
 
-class Wysiwyg extends Field
+class WysiwygEditor extends Field
 {
     use ConditionalLogic;
     use DefaultValue;

--- a/tests/Fields/RadioTest.php
+++ b/tests/Fields/RadioTest.php
@@ -14,13 +14,13 @@ declare(strict_types=1);
 namespace WordPlate\Tests\Acf\Fields;
 
 use PHPUnit\Framework\TestCase;
-use WordPlate\Acf\Fields\Radio;
+use WordPlate\Acf\Fields\RadioButton;
 
-class RadioTest extends TestCase
+class RadioButtonTest extends TestCase
 {
     public function testType()
     {
-        $field = Radio::make('Radio')->toArray();
+        $field = RadioButton::make('Radio Button')->toArray();
         $this->assertSame('radio', $field['type']);
     }
 }

--- a/tests/Fields/TextTest.php
+++ b/tests/Fields/TextTest.php
@@ -30,8 +30,8 @@ class TextTest extends TestCase
         $field = Text::make('Email')->toArray();
         $this->assertSame('email', $field['name']);
 
-        $field = Text::make('Category', 'tag')->toArray();
-        $this->assertSame('tag', $field['name']);
+        $field = Text::make('Category Tag', 'category_tag')->toArray();
+        $this->assertSame('category_tag', $field['name']);
     }
 
     public function testKey()

--- a/tests/Fields/WysiwygEditorTest.php
+++ b/tests/Fields/WysiwygEditorTest.php
@@ -15,36 +15,36 @@ namespace WordPlate\Tests\Acf\Fields;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-use WordPlate\Acf\Fields\Wysiwyg;
+use WordPlate\Acf\Fields\WysiwygEditor;
 
-class WysiwygTest extends TestCase
+class WysiwygEditorTest extends TestCase
 {
     public function testType()
     {
-        $field = Wysiwyg::make('Wysiwyg')->toArray();
+        $field = WysiwygEditor::make('Wysiwyg Editor')->toArray();
         $this->assertSame('wysiwyg', $field['type']);
     }
 
     public function testMediaUpload()
     {
-        $field = Wysiwyg::make('Wysiwyg Media Upload')->mediaUpload(false)->toArray();
+        $field = WysiwygEditor::make('Wysiwyg Editor Media Upload')->mediaUpload(false)->toArray();
         $this->assertFalse($field['media_upload']);
     }
 
     public function testTabs()
     {
-        $field = Wysiwyg::make('Wysiwyg Tabs')->tabs('visual')->toArray();
+        $field = WysiwygEditor::make('Wysiwyg Editor Tabs')->tabs('visual')->toArray();
         $this->assertSame('visual', $field['tabs']);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid argument tabs [test].');
 
-        $field = Wysiwyg::make('Wysiwyg Inavlid Tabs')->tabs('test')->toArray();
+        $field = WysiwygEditor::make('Wysiwyg Editor Inavlid Tabs')->tabs('test')->toArray();
     }
 
     public function testToolbar()
     {
-        $field = Wysiwyg::make('Wysiwyg Toolbar')->toolbar('basic')->toArray();
+        $field = WysiwygEditor::make('Wysiwyg Editor Toolbar')->toolbar('basic')->toArray();
         $this->assertSame('basic', $field['toolbar']);
     }
 }


### PR DESCRIPTION
- Added `readonly` and `disabled` to date fields

- Rename `Radio` class to `RadioButton`

- Rename `Wysiwyg` class to `WysiwygEditor`

- Updated field label to name conversion from `kebab-case` to `snake_case`
	
	If no field name is specified the library will use the label instead. The has previously only been sanitised using the `sanitize_title` function in WordPress. This PR will convert the name into `snake_case` instead of `kebab-case`.
