### PR TITLE
Added new location API

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ The location class let you write [custom location rules](https://www.advancedcus
 ```php
 use WordPlate\Acf\Location;
 
-Location::if('post_type')->equals('post')->and('post_type')->notEquals('!=', 'post');
+Location::if('post_type')->equals('post')->and('post_type')->notEquals('post');
 ```
 
 ## Conditional Logic

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ add_action('acf/init', function() {
             Text::make('Title'),
         ],
         'location' => [
-            Location::if('post_type', 'page')
+            Location::if('post_type')->equals('page')
         ],
     ]);
 });
@@ -608,7 +608,7 @@ The location class let you write [custom location rules](https://www.advancedcus
 ```php
 use WordPlate\Acf\Location;
 
-Location::if('post_type', 'post')->and('post_type', '!=', 'post');
+Location::if('post_type')->equals('post')->and('post_type')->notEquals('!=', 'post');
 ```
 
 ## Conditional Logic

--- a/src/Location.php
+++ b/src/Location.php
@@ -15,34 +15,42 @@ namespace WordPlate\Acf;
 
 class Location
 {
-    protected $rules = [];
-
-    /** @param string $param post_type, post_template, post_status, post_format, post_category, post_taxonomy, post, page_template, page_type, page_parent, page, current_user, current_user_role, user_form, user_role, taxonomy, attachment, comment, widget, nav_menu, nav_menu, nav_menu_item, block or options_page */
-    public function __construct(string $param, string $operator, string|null $value = null)
-    {
-        $this->rules[] = compact('param', 'operator', 'value');
+    public function __construct(
+        protected array $rules = []
+    ) {
+        //
     }
 
     /** @param string $param post_type, post_template, post_status, post_format, post_category, post_taxonomy, post, page_template, page_type, page_parent, page, current_user, current_user_role, user_form, user_role, taxonomy, attachment, comment, widget, nav_menu, nav_menu, nav_menu_item, block or options_page */
-    public static function if(string $param, string $operator, string|null $value = null): static
+    public static function if(string $param): static
     {
-        if (func_num_args() === 2) {
-            $value = $operator;
-            $operator = '==';
-        }
+        return new self([['param' => $param]]);
+    }
 
-        return new self($param, $operator, $value);
+    public function equals(string|null $value = null): static
+    {
+        $key = array_key_last($this->rules);
+
+        $this->rules[$key]['operator'] = '==';
+        $this->rules[$key]['value'] = $value;
+
+        return $this;
+    }
+
+    public function notEquals(string|null $value = null): static
+    {
+        $key = array_key_last($this->rules);
+
+        $this->rules[$key]['operator'] = '!=';
+        $this->rules[$key]['value'] = $value;
+
+        return $this;
     }
 
     /** @param string $param post_type, post_template, post_status, post_format, post_category, post_taxonomy, post, page_template, page_type, page_parent, page, current_user, current_user_role, user_form, user_role, taxonomy, attachment, comment, widget, nav_menu, nav_menu, nav_menu_item, block or options_page */
-    public function and(string $param, string $operator, string|null $value = null): static
+    public function and(string $param): static
     {
-        if (func_num_args() === 2) {
-            $value = $operator;
-            $operator = '==';
-        }
-
-        $this->rules[] = compact('param', 'operator', 'value');
+        $this->rules[] = ['param' => $param];
 
         return $this;
     }

--- a/tests/LocationTest.php
+++ b/tests/LocationTest.php
@@ -28,8 +28,7 @@ class LocationTest extends TestCase
             ],
         ];
 
-        $this->assertSame($location, Location::if('post_type', 'post')->toArray());
-        $this->assertSame($location, Location::if('post_type', '==', 'post')->toArray());
+        $this->assertSame($location, Location::if('post_type')->equals('post')->toArray());
     }
 
     public function testAnd()
@@ -42,11 +41,11 @@ class LocationTest extends TestCase
             ],
             [
                 'param' => 'post_type',
-                'operator' => '==',
+                'operator' => '!=',
                 'value' => 'employee',
             ],
         ];
 
-        $this->assertSame($location, Location::if('post_type', 'post')->and('post_type', 'employee')->toArray());
+        $this->assertSame($location, Location::if('post_type')->equals('post')->and('post_type')->notEquals('employee')->toArray());
     }
 }


### PR DESCRIPTION
This is a proposal to make the location API more similar to the conditional logic API.

```php
// Before
Location::if('post_type', 'post')->and('post_type', '!=', 'post');

// After
Location::if('post_type')->equals('post')->and('post_type')->notEquals('post');
```

I'm opening this to see if the community has any suggestions or feedback on why this should or shouldn't change.